### PR TITLE
Fix forward pass using GPU other than index 0

### DIFF
--- a/ultra/rspmm/source/rspmm.cu
+++ b/ultra/rspmm/source/rspmm.cu
@@ -241,7 +241,7 @@ Tensor rspmm_forward_cuda(const Tensor &edge_index_, const Tensor &edge_type_, c
     Tensor layer_ind = edge_type;
 
     cudaSetDevice(input.get_device());
-    auto stream = at::cuda::getCurrentCUDAStream();
+    auto stream = at::cuda::getCurrentCUDAStream(input.get_device());
 
     const int dim_per_block = 32; // warpSize
     const int num_dim_block = (dim + dim_per_block * kCoarseningFactor - 1) / (dim_per_block * kCoarseningFactor);


### PR DESCRIPTION
This PR fixes #20.

I'm not really familiar with CUDA, so am not sure why the `cudaSetDevice` on L243 is insufficient. I'm also not sure why there's no need to make the same type of change in the backwards pass function, but it seems to work only making this one change.

https://github.com/DeepGraphLearning/ULTRA/blob/c414f83d9ec1e4726f396c24beab6311a2869f1a/ultra/rspmm/source/rspmm.cu#L305